### PR TITLE
Prevent clearing of latest_status table

### DIFF
--- a/tools/load/README.md
+++ b/tools/load/README.md
@@ -69,7 +69,6 @@ truncate table xnode cascade;
 truncate table xremoteresource cascade;
 truncate table xretirement cascade;
 truncate table xstorage cascade;
-truncate table latest_status;
 ```
 
 #### Reset sequences


### PR DESCRIPTION
Don't remove latest_status table, this is information provided outside of the asset management files.  Reloading asset management data will not restore this information.  Truncating this table will loose the information it contained and it would not be easily restored.