### PR TITLE
Addition of SBS CDOM correction for gliders and AUVs

### DIFF
--- a/calibration/FLORTM/CGINS-FLORTM-02110__20110127.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-02110__20110127.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 2110,CC_depolarization_ratio,0.039,
 2110,CC_measurement_wavelength,700.0,
 2110,CC_scattering_angle,124.0,
+2110,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-02110__20130213.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-02110__20130213.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 2110,CC_depolarization_ratio,0.039,
 2110,CC_measurement_wavelength,700.0,
 2110,CC_scattering_angle,124.0,
+2110,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-02760__20120816.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-02760__20120816.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 2760,CC_depolarization_ratio,0.039,
 2760,CC_measurement_wavelength,700.0,
 2760,CC_scattering_angle,124.0,
+2760,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-02761__20120816.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-02761__20120816.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 2761,CC_depolarization_ratio,0.039,
 2761,CC_measurement_wavelength,700.0,
 2761,CC_scattering_angle,124.0,
+2761,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-02762__20120821.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-02762__20120821.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 2762,CC_depolarization_ratio,0.039,
 2762,CC_measurement_wavelength,700.0,
 2762,CC_scattering_angle,124.0,
+2762,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-02786__20120816.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-02786__20120816.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 2786,CC_depolarization_ratio,0.039,
 2786,CC_measurement_wavelength,700.0,
 2786,CC_scattering_angle,124.0,
+2786,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-02806__20120920.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-02806__20120920.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 2806,CC_depolarization_ratio,0.039,
 2806,CC_measurement_wavelength,700.0,
 2806,CC_scattering_angle,124.0,
+2806,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-02807__20120920.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-02807__20120920.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 2807,CC_depolarization_ratio,0.039,
 2807,CC_measurement_wavelength,700.0,
 2807,CC_scattering_angle,124.0,
+2807,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-02809__20121016.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-02809__20121016.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 2809,CC_depolarization_ratio,0.039,
 2809,CC_measurement_wavelength,700.0,
 2809,CC_scattering_angle,124.0,
+2809,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-02812__20130208.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-02812__20130208.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 2812,CC_depolarization_ratio,0.039,
 2812,CC_measurement_wavelength,700.0,
 2812,CC_scattering_angle,124.0,
+2812,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-02812__20150929.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-02812__20150929.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 2812,CC_depolarization_ratio,0.039,
 2812,CC_measurement_wavelength,700.0,
 2812,CC_scattering_angle,124.0,
+2812,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-02813__20130211.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-02813__20130211.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 2813,CC_depolarization_ratio,0.039,
 2813,CC_measurement_wavelength,700.0,
 2813,CC_scattering_angle,124.0,
+2813,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-02817__20130314.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-02817__20130314.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 2817,CC_depolarization_ratio,0.039,
 2817,CC_measurement_wavelength,700.0,
 2817,CC_scattering_angle,124.0,
+2817,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-02818__20130314.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-02818__20130314.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 2818,CC_depolarization_ratio,0.039,
 2818,CC_measurement_wavelength,700.0,
 2818,CC_scattering_angle,124.0,
+2818,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-02819__20130314.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-02819__20130314.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 2819,CC_depolarization_ratio,0.039,
 2819,CC_measurement_wavelength,700.0,
 2819,CC_scattering_angle,124.0,
+2819,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-02858__20121207.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-02858__20121207.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 2858,CC_depolarization_ratio,0.039,
 2858,CC_measurement_wavelength,700.0,
 2858,CC_scattering_angle,124.0,
+2858,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-03015__20130213.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03015__20130213.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3015,CC_depolarization_ratio,0.039,
 3015,CC_measurement_wavelength,700.0,
 3015,CC_scattering_angle,124.0,
+3015,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-03116__20130502.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03116__20130502.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3116,CC_depolarization_ratio,0.039,
 3116,CC_measurement_wavelength,700.0,
 3116,CC_scattering_angle,124.0,
+3116,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-03116__20161019.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03116__20161019.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3116,CC_depolarization_ratio,0.039,
 3116,CC_measurement_wavelength,700.0,
 3116,CC_scattering_angle,124.0,
+3116,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-03116__20190912.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03116__20190912.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3116,CC_depolarization_ratio,0.039,
 3116,CC_measurement_wavelength,700.0,
 3116,CC_scattering_angle,124.0,
+3116,CC_cdom_correction_factor,2.505136,Sea-Bird provided CDOM correction factor: 2.505136 = 5.62 * 0.445754

--- a/calibration/FLORTM/CGINS-FLORTM-03130__20130509.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03130__20130509.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3130,CC_depolarization_ratio,0.039,
 3130,CC_measurement_wavelength,700.0,
 3130,CC_scattering_angle,124.0,
+3130,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-03130__20161021.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03130__20161021.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3130,CC_depolarization_ratio,0.039,
 3130,CC_measurement_wavelength,700,
 3130,CC_scattering_angle,124,
+3130,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-03130__20180212.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03130__20180212.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3130,CC_depolarization_ratio,0.039,
 3130,CC_measurement_wavelength,700,
 3130,CC_scattering_angle,124,
+3130,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-03130__20201230.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03130__20201230.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3130,CC_depolarization_ratio,0.039,
 3130,CC_measurement_wavelength,700,
 3130,CC_scattering_angle,124,
+3130,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-03130__20220830.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03130__20220830.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3130,CC_depolarization_ratio,0.039,
 3130,CC_measurement_wavelength,700,
 3130,CC_scattering_angle,124,
+3130,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-03131__20130509.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03131__20130509.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3131,CC_depolarization_ratio,0.039,
 3131,CC_measurement_wavelength,700.0,
 3131,CC_scattering_angle,124.0,
+3131,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-03131__20170317.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03131__20170317.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3131,CC_depolarization_ratio,0.039,
 3131,CC_measurement_wavelength,700.0,
 3131,CC_scattering_angle,124.0,
+3131,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-03131__20200413.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03131__20200413.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3131,CC_depolarization_ratio,0.039,
 3131,CC_measurement_wavelength,700.0,
 3131,CC_scattering_angle,124.0,
+3131,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-03131__20220805.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03131__20220805.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3131,CC_depolarization_ratio,0.039,
 3131,CC_measurement_wavelength,700.0,
 3131,CC_scattering_angle,124.0,
+3131,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-03131__20240319.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03131__20240319.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3131,CC_depolarization_ratio,0.039,
 3131,CC_measurement_wavelength,700.0,
 3131,CC_scattering_angle,124.0,
+3131,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTM/CGINS-FLORTM-03185__20130610.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03185__20130610.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3185,CC_depolarization_ratio,0.039,
 3185,CC_measurement_wavelength,700.0,
 3185,CC_scattering_angle,124.0,
+3185,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-03185__20160913.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03185__20160913.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3185,CC_depolarization_ratio,0.039,
 3185,CC_measurement_wavelength,700,
 3185,CC_scattering_angle,124,
+3185,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-03185__20190724.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03185__20190724.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3185,CC_depolarization_ratio,0.039,
 3185,CC_measurement_wavelength,700,
 3185,CC_scattering_angle,124,
+3185,CC_cdom_correction_factor,2.505136,Sea-Bird provided CDOM correction factor: 2.505136 = 5.62 * 0.445754

--- a/calibration/FLORTM/CGINS-FLORTM-03185__20201231.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03185__20201231.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3185,CC_depolarization_ratio,0.039,
 3185,CC_measurement_wavelength,700,
 3185,CC_scattering_angle,124,
+3185,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-03185__20220808.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03185__20220808.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3185,CC_depolarization_ratio,0.039,
 3185,CC_measurement_wavelength,700,
 3185,CC_scattering_angle,124,
+3185,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-03186__20130612.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03186__20130612.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3186,CC_depolarization_ratio,0.039,
 3186,CC_measurement_wavelength,700.0,
 3186,CC_scattering_angle,124.0,
+3186,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-03186__20160614.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03186__20160614.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3186,CC_depolarization_ratio,0.039,
 3186,CC_measurement_wavelength,700.0,
 3186,CC_scattering_angle,124.0,
+3186,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-03186__20191025.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03186__20191025.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3186,CC_depolarization_ratio,0.039,
 3186,CC_measurement_wavelength,700.0,
 3186,CC_scattering_angle,124.0,
+3186,CC_cdom_correction_factor,2.505136,Sea-Bird provided CDOM correction factor: 2.505136 = 5.62 * 0.445754

--- a/calibration/FLORTM/CGINS-FLORTM-03186__20220121.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03186__20220121.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3186,CC_depolarization_ratio,0.039,
 3186,CC_measurement_wavelength,700.0,
 3186,CC_scattering_angle,124.0,
+3186,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-03188__20130610.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03188__20130610.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3188,CC_depolarization_ratio,0.039,
 3188,CC_measurement_wavelength,700.0,
 3188,CC_scattering_angle,124.0,
+3188,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-03188__20170317.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03188__20170317.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3188,CC_depolarization_ratio,0.039,
 3188,CC_measurement_wavelength,700.0,
 3188,CC_scattering_angle,124.0,
+3188,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-03188__20200413.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03188__20200413.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3188,CC_depolarization_ratio,0.039,
 3188,CC_measurement_wavelength,700.0,
 3188,CC_scattering_angle,124.0,
+3188,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-03188__20220120.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03188__20220120.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3188,CC_depolarization_ratio,0.039,
 3188,CC_measurement_wavelength,700.0,
 3188,CC_scattering_angle,124.0,
+3188,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-03189__20130610.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03189__20130610.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3189,CC_depolarization_ratio,0.039,
 3189,CC_measurement_wavelength,700.0,
 3189,CC_scattering_angle,124.0,
+3189,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-03189__20170530.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03189__20170530.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3189,CC_depolarization_ratio,0.039,
 3189,CC_measurement_wavelength,700.0,
 3189,CC_scattering_angle,124.0,
+3189,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-03189__20190528.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03189__20190528.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3189,CC_depolarization_ratio,0.039,
 3189,CC_measurement_wavelength,700.0,
 3189,CC_scattering_angle,124.0,
+3189,CC_cdom_correction_factor,2.505136,Sea-Bird provided CDOM correction factor: 2.505136 = 5.62 * 0.445754

--- a/calibration/FLORTM/CGINS-FLORTM-03189__20201203.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03189__20201203.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3189,CC_depolarization_ratio,0.039,
 3189,CC_measurement_wavelength,700.0,
 3189,CC_scattering_angle,124.0,
+3189,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-03189__20230410.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03189__20230410.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3189,CC_depolarization_ratio,0.039,
 3189,CC_measurement_wavelength,700.0,
 3189,CC_scattering_angle,124.0,
+3189,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTM/CGINS-FLORTM-03190__20130612.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03190__20130612.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3190,CC_depolarization_ratio,0.039,
 3190,CC_measurement_wavelength,700.0,
 3190,CC_scattering_angle,124.0,
+3190,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-03190__20170530.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03190__20170530.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3190,CC_depolarization_ratio,0.039,
 3190,CC_measurement_wavelength,700.0,
 3190,CC_scattering_angle,124.0,
+3190,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-03190__20200423.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03190__20200423.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3190,CC_depolarization_ratio,0.039,
 3190,CC_measurement_wavelength,700,
 3190,CC_scattering_angle,124,
+3190,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-03190__20220804.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03190__20220804.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3190,CC_depolarization_ratio,0.039,
 3190,CC_measurement_wavelength,700,
 3190,CC_scattering_angle,124,
+3190,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-03206__20130717.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03206__20130717.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3206,CC_depolarization_ratio,0.039,
 3206,CC_measurement_wavelength,700.0,
 3206,CC_scattering_angle,124.0,
+3206,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-03206__20170530.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03206__20170530.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3206,CC_depolarization_ratio,0.039,
 3206,CC_measurement_wavelength,700.0,
 3206,CC_scattering_angle,124.0,
+3206,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-03207__20130717.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03207__20130717.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3207,CC_depolarization_ratio,0.039,
 3207,CC_measurement_wavelength,700,
 3207,CC_scattering_angle,124,
+3207,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-03207__20161020.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03207__20161020.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3207,CC_depolarization_ratio,0.039,
 3207,CC_measurement_wavelength,700,
 3207,CC_scattering_angle,124,
+3207,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-03207__20180531.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03207__20180531.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3207,CC_depolarization_ratio,0.039,
 3207,CC_measurement_wavelength,700,
 3207,CC_scattering_angle,124,
+3207,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-03207__20191025.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03207__20191025.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3207,CC_depolarization_ratio,0.039,
 3207,CC_measurement_wavelength,700,
 3207,CC_scattering_angle,124,
+3207,CC_cdom_correction_factor,2.505136,Sea-Bird provided CDOM correction factor: 2.505136 = 5.62 * 0.445754

--- a/calibration/FLORTM/CGINS-FLORTM-03207__20201231.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03207__20201231.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3207,CC_depolarization_ratio,0.039,
 3207,CC_measurement_wavelength,700,
 3207,CC_scattering_angle,124,
+3207,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-03260__20130808.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03260__20130808.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3260,CC_depolarization_ratio,0.039,
 3260,CC_measurement_wavelength,700.0,
 3260,CC_scattering_angle,124,
+3260,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTM/CGINS-FLORTM-03260__20160210.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03260__20160210.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3260,CC_depolarization_ratio,0.039,
 3260,CC_measurement_wavelength,700,
 3260,CC_scattering_angle,124,
+3260,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-03260__20200317.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03260__20200317.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3260,CC_depolarization_ratio,0.039,
 3260,CC_measurement_wavelength,700,
 3260,CC_scattering_angle,124,
+3260,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-03500__20140224.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03500__20140224.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3500,CC_depolarization_ratio,0.039,
 3500,CC_measurement_wavelength,700,
 3500,CC_scattering_angle,124,
+3500,CC_cdom_correction_factor,1.245926,Sea-Bird provided CDOM correction factor: 1.245926 = 5.62 * 0.221695

--- a/calibration/FLORTM/CGINS-FLORTM-03501__20140224.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03501__20140224.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3501,CC_depolarization_ratio,0.039,
 3501,CC_measurement_wavelength,700.0,
 3501,CC_scattering_angle,124.0,
+3501,CC_cdom_correction_factor,1.245926,Sea-Bird provided CDOM correction factor: 1.245926 = 5.62 * 0.221695

--- a/calibration/FLORTM/CGINS-FLORTM-03501__20170706.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03501__20170706.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3501,CC_depolarization_ratio,0.039,
 3501,CC_measurement_wavelength,700.0,
 3501,CC_scattering_angle,124.0,
+3501,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-03501__20200208.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03501__20200208.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3501,CC_depolarization_ratio,0.039,
 3501,CC_measurement_wavelength,700.0,
 3501,CC_scattering_angle,124.0,
+3501,CC_cdom_correction_factor,2.505136,Sea-Bird provided CDOM correction factor: 2.505136 = 5.62 * 0.445754

--- a/calibration/FLORTM/CGINS-FLORTM-03501__20220111.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03501__20220111.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3501,CC_depolarization_ratio,0.039,
 3501,CC_measurement_wavelength,700.0,
 3501,CC_scattering_angle,124.0,
+3501,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-03777__20141216.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03777__20141216.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3777,CC_depolarization_ratio,0.039,
 3777,CC_measurement_wavelength,700,
 3777,CC_scattering_angle,124,
+3777,CC_cdom_correction_factor,1.245926,Sea-Bird provided CDOM correction factor: 1.245926 = 5.62 * 0.221695

--- a/calibration/FLORTM/CGINS-FLORTM-03783__20150115.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03783__20150115.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3783,CC_depolarization_ratio,0.039,
 3783,CC_measurement_wavelength,700,
 3783,CC_scattering_angle,124,
+3783,CC_cdom_correction_factor,1.245926,Sea-Bird provided CDOM correction factor: 1.245926 = 5.62 * 0.221695

--- a/calibration/FLORTM/CGINS-FLORTM-03813__20150115.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03813__20150115.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3813,CC_depolarization_ratio,0.039,
 3813,CC_measurement_wavelength,700,
 3813,CC_scattering_angle,124,
+3813,CC_cdom_correction_factor,1.245926,Sea-Bird provided CDOM correction factor: 1.245926 = 5.62 * 0.221695

--- a/calibration/FLORTM/CGINS-FLORTM-03813__20190911.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03813__20190911.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3813,CC_depolarization_ratio,0.039,
 3813,CC_measurement_wavelength,700,
 3813,CC_scattering_angle,124,
+3813,CC_cdom_correction_factor,2.505136,Sea-Bird provided CDOM correction factor: 2.505136 = 5.62 * 0.445754

--- a/calibration/FLORTM/CGINS-FLORTM-03814__20150115.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03814__20150115.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3814,CC_depolarization_ratio,0.039,
 3814,CC_measurement_wavelength,700,
 3814,CC_scattering_angle,124,
+3814,CC_cdom_correction_factor,1.245926,Sea-Bird provided CDOM correction factor: 1.245926 = 5.62 * 0.221695

--- a/calibration/FLORTM/CGINS-FLORTM-03814__20211005.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03814__20211005.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3814,CC_depolarization_ratio,0.039,
 3814,CC_measurement_wavelength,700,
 3814,CC_scattering_angle,124,
+3814,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-03815__20150115.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03815__20150115.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3815,CC_depolarization_ratio,0.039,
 3815,CC_measurement_wavelength,700,
 3815,CC_scattering_angle,124,
+3815,CC_cdom_correction_factor,1.245926,Sea-Bird provided CDOM correction factor: 1.245926 = 5.62 * 0.221695

--- a/calibration/FLORTM/CGINS-FLORTM-03815__20190326.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03815__20190326.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3815,CC_depolarization_ratio,0.039,
 3815,CC_measurement_wavelength,700,
 3815,CC_scattering_angle,124,
+3815,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-03815__20220328.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03815__20220328.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3815,CC_depolarization_ratio,0.039,
 3815,CC_measurement_wavelength,700,
 3815,CC_scattering_angle,124,
+3815,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-03884__20150212.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03884__20150212.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3884,CC_depolarization_ratio,0.039,
 3884,CC_measurement_wavelength,700.0,
 3884,CC_scattering_angle,124.0,
+3884,CC_cdom_correction_factor,1.245926,Sea-Bird provided CDOM correction factor: 1.245926 = 5.62 * 0.221695

--- a/calibration/FLORTM/CGINS-FLORTM-03884__20160914.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03884__20160914.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3884,CC_depolarization_ratio,0.039,
 3884,CC_measurement_wavelength,700,
 3884,CC_scattering_angle,124,
+3884,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-03884__20191104.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03884__20191104.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3884,CC_depolarization_ratio,0.039,
 3884,CC_measurement_wavelength,700,
 3884,CC_scattering_angle,124,
+3884,CC_cdom_correction_factor,2.505136,Sea-Bird provided CDOM correction factor: 2.505136 = 5.62 * 0.445754

--- a/calibration/FLORTM/CGINS-FLORTM-03884__20210831.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03884__20210831.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3884,CC_depolarization_ratio,0.039,
 3884,CC_measurement_wavelength,700,
 3884,CC_scattering_angle,124,
+3884,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-03884__20250115.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03884__20250115.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3884,CC_depolarization_ratio,0.039,
 3884,CC_measurement_wavelength,700,
 3884,CC_scattering_angle,124,
+3884,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTM/CGINS-FLORTM-03921__20150323.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03921__20150323.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3921,CC_depolarization_ratio,0.039,
 3921,CC_measurement_wavelength,700.0,
 3921,CC_scattering_angle,124.0,
+3921,CC_cdom_correction_factor,1.245926,Sea-Bird provided CDOM correction factor: 1.245926 = 5.62 * 0.221695

--- a/calibration/FLORTM/CGINS-FLORTM-03921__20170530.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03921__20170530.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3921,CC_depolarization_ratio,0.039,constant
 3921,CC_measurement_wavelength,700.0,constant
 3921,CC_scattering_angle,124.0,constant
+3921,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-03921__20180108.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03921__20180108.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3921,CC_depolarization_ratio,0.039,constant
 3921,CC_measurement_wavelength,700.0,constant
 3921,CC_scattering_angle,124.0,constant
+3921,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-03921__20200910.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03921__20200910.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3921,CC_depolarization_ratio,0.039,constant
 3921,CC_measurement_wavelength,700.0,constant
 3921,CC_scattering_angle,124.0,constant
+3921,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-03921__20220427.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03921__20220427.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3921,CC_depolarization_ratio,0.039,
 3921,CC_measurement_wavelength,700.0,
 3921,CC_scattering_angle,124.0,
+3921,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-03938__20170410.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-03938__20170410.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 3938,CC_depolarization_ratio,0.039,
 3938,CC_measurement_wavelength,700.0,
 3938,CC_scattering_angle,124.0,
+3938,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04039__20151220.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04039__20151220.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4039,CC_depolarization_ratio,0.039,
 4039,CC_measurement_wavelength,700,
 4039,CC_scattering_angle,124,
+4039,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04039__20190326.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04039__20190326.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4039,CC_depolarization_ratio,0.039,
 4039,CC_measurement_wavelength,700,
 4039,CC_scattering_angle,124,
+4039,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04039__20250109.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04039__20250109.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4039,CC_depolarization_ratio,0.039,
 4039,CC_measurement_wavelength,700,
 4039,CC_scattering_angle,124,
+4039,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTM/CGINS-FLORTM-04040__20150623.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04040__20150623.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4040,CC_depolarization_ratio,0.039,
 4040,CC_measurement_wavelength,700.0,
 4040,CC_scattering_angle,124.0,
+4040,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04040__20160927.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04040__20160927.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4040,CC_depolarization_ratio,0.039,
 4040,CC_measurement_wavelength,700.0,
 4040,CC_scattering_angle,124.0,
+4040,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04040__20190610.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04040__20190610.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4040,CC_depolarization_ratio,0.039,
 4040,CC_measurement_wavelength,700.0,
 4040,CC_scattering_angle,124.0,
+4040,CC_cdom_correction_factor,2.505136,Sea-Bird provided CDOM correction factor: 2.505136 = 5.62 * 0.445754

--- a/calibration/FLORTM/CGINS-FLORTM-04040__20220304.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04040__20220304.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4040,CC_depolarization_ratio,0.039,
 4040,CC_measurement_wavelength,700.0,
 4040,CC_scattering_angle,124.0,
+4040,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04040__20240613.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04040__20240613.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4040,CC_depolarization_ratio,0.039,
 4040,CC_measurement_wavelength,700.0,
 4040,CC_scattering_angle,124.0,
+4040,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTM/CGINS-FLORTM-04041__20150623.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04041__20150623.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4041,CC_depolarization_ratio,0.039,
 4041,CC_measurement_wavelength,700,
 4041,CC_scattering_angle,124,
+4041,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04041__20170530.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04041__20170530.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4041,CC_depolarization_ratio,0.039,
 4041,CC_measurement_wavelength,700,
 4041,CC_scattering_angle,124,
+4041,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04041__20200429.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04041__20200429.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4041,CC_depolarization_ratio,0.039,
 4041,CC_measurement_wavelength,700,
 4041,CC_scattering_angle,124,
+4041,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04041__20220808.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04041__20220808.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4041,CC_depolarization_ratio,0.039,
 4041,CC_measurement_wavelength,700.0,
 4041,CC_scattering_angle,124.0,
+4041,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04088__20150825.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04088__20150825.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4088,CC_depolarization_ratio,0.039,
 4088,CC_measurement_wavelength,700,
 4088,CC_scattering_angle,124,
+4088,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04089__20150825.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04089__20150825.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4089,CC_depolarization_ratio,0.039,
 4089,CC_measurement_wavelength,700,
 4089,CC_scattering_angle,124,
+4089,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04089__20200210.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04089__20200210.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4089,CC_depolarization_ratio,0.039,
 4089,CC_measurement_wavelength,700,
 4089,CC_scattering_angle,124,
+4089,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04089__20220805.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04089__20220805.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4089,CC_depolarization_ratio,0.039,
 4089,CC_measurement_wavelength,700,
 4089,CC_scattering_angle,124,
+4089,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04090__20150826.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04090__20150826.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4090,CC_depolarization_ratio,0.039,
 4090,CC_measurement_wavelength,700,
 4090,CC_scattering_angle,124,
+4090,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04091__20150826.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04091__20150826.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4091,CC_depolarization_ratio,0.039,
 4091,CC_measurement_wavelength,700,
 4091,CC_scattering_angle,124,
+4091,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04092__20150826.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04092__20150826.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4092,CC_depolarization_ratio,0.039,
 4092,CC_measurement_wavelength,700,
 4092,CC_scattering_angle,124,
+4092,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04093__20150826.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04093__20150826.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4093,CC_depolarization_ratio,0.039,
 4093,CC_measurement_wavelength,700,
 4093,CC_scattering_angle,124,
+4093,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04093__20190627.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04093__20190627.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4093,CC_depolarization_ratio,0.039,
 4093,CC_measurement_wavelength,700,
 4093,CC_scattering_angle,124,
+4093,CC_cdom_correction_factor,2.505136,Sea-Bird provided CDOM correction factor: 2.505136 = 5.62 * 0.445754

--- a/calibration/FLORTM/CGINS-FLORTM-04093__20210715.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04093__20210715.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4093,CC_depolarization_ratio,0.039,
 4093,CC_measurement_wavelength,700,
 4093,CC_scattering_angle,124,
+4093,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04093__20240103.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04093__20240103.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4093,CC_depolarization_ratio,0.039,
 4093,CC_measurement_wavelength,700,
 4093,CC_scattering_angle,124,
+4093,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTM/CGINS-FLORTM-04100__20150826.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04100__20150826.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4100,CC_depolarization_ratio,0.039,
 4100,CC_measurement_wavelength,700,
 4100,CC_scattering_angle,124,
+4100,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04101__20150826.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04101__20150826.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4101,CC_depolarization_ratio,0.039,
 4101,CC_measurement_wavelength,700,
 4101,CC_scattering_angle,124,
+4101,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04101__20201013.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04101__20201013.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4101,CC_depolarization_ratio,0.039,
 4101,CC_measurement_wavelength,700,
 4101,CC_scattering_angle,124,
+4101,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04101__20220304.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04101__20220304.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4101,CC_depolarization_ratio,0.039,
 4101,CC_measurement_wavelength,700,
 4101,CC_scattering_angle,124,
+4101,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04194__20160114.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04194__20160114.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4194,CC_depolarization_ratio,0.039,
 4194,CC_measurement_wavelength,700,
 4194,CC_scattering_angle,124,
+4194,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04194__20190911.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04194__20190911.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4194,CC_depolarization_ratio,0.039,
 4194,CC_measurement_wavelength,700,
 4194,CC_scattering_angle,124,
+4194,CC_cdom_correction_factor,2.505136,Sea-Bird provided CDOM correction factor: 2.505136 = 5.62 * 0.445754

--- a/calibration/FLORTM/CGINS-FLORTM-04194__20220427.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04194__20220427.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4194,CC_depolarization_ratio,0.039,
 4194,CC_measurement_wavelength,700,
 4194,CC_scattering_angle,124,
+4194,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04195__20160114.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04195__20160114.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4195,CC_depolarization_ratio,0.039,
 4195,CC_measurement_wavelength,700,
 4195,CC_scattering_angle,124,
+4195,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04195__20170315.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04195__20170315.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4195,CC_depolarization_ratio,0.039,
 4195,CC_measurement_wavelength,700,
 4195,CC_scattering_angle,124,
+4195,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04195__20200413.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04195__20200413.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4195,CC_depolarization_ratio,0.039,constant
 4195,CC_measurement_wavelength,700,constant
 4195,CC_scattering_angle,124,constant
+4195,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04195__20220804.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04195__20220804.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4195,CC_depolarization_ratio,0.039,constant
 4195,CC_measurement_wavelength,700,constant
 4195,CC_scattering_angle,124,constant
+4195,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04196__20160208.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04196__20160208.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4196,CC_depolarization_ratio,0.039,
 4196,CC_measurement_wavelength,700.0,
 4196,CC_scattering_angle,124.0,
+4196,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04196__20170315.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04196__20170315.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4196,CC_depolarization_ratio,0.039,
 4196,CC_measurement_wavelength,700.0,
 4196,CC_scattering_angle,124.0,
+4196,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04197__20151119.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04197__20151119.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4197,CC_depolarization_ratio,0.039,
 4197,CC_measurement_wavelength,700.0,
 4197,CC_scattering_angle,124.0,
+4197,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04197__20170925.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04197__20170925.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4197,CC_depolarization_ratio,0.039,
 4197,CC_measurement_wavelength,700.0,
 4197,CC_scattering_angle,124.0,
+4197,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04198__20151215.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04198__20151215.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4198,CC_depolarization_ratio,0.039,
 4198,CC_measurement_wavelength,700,
 4198,CC_scattering_angle,124,
+4198,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04198__20180103.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04198__20180103.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4198,CC_depolarization_ratio,0.039,
 4198,CC_measurement_wavelength,700,
 4198,CC_scattering_angle,124,
+4198,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04201__20160111.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04201__20160111.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4201,CC_depolarization_ratio,0.039,
 4201,CC_measurement_wavelength,700.0,
 4201,CC_scattering_angle,124.0,
+4201,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04201__20201013.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04201__20201013.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4201,CC_depolarization_ratio,0.039,
 4201,CC_measurement_wavelength,700,
 4201,CC_scattering_angle,124,
+4201,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04201__20220427.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04201__20220427.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4201,CC_depolarization_ratio,0.039,
 4201,CC_measurement_wavelength,700,
 4201,CC_scattering_angle,124,
+4201,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04202__20160111.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04202__20160111.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4202,CC_depolarization_ratio,0.039,
 4202,CC_measurement_wavelength,700.0,
 4202,CC_scattering_angle,124.0,
+4202,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04202__20201203.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04202__20201203.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4202,CC_depolarization_ratio,0.039,
 4202,CC_measurement_wavelength,700.0,
 4202,CC_scattering_angle,124.0,
+4202,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04202__20230701.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04202__20230701.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4202,CC_depolarization_ratio,0.039,
 4202,CC_measurement_wavelength,700.0,
 4202,CC_scattering_angle,124.0,
+4202,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTM/CGINS-FLORTM-04220__20160205.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04220__20160205.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4220,CC_depolarization_ratio,0.039,
 4220,CC_measurement_wavelength,700.0,
 4220,CC_scattering_angle,124.0,
+4220,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04220__20180102.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04220__20180102.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4220,CC_depolarization_ratio,0.039,
 4220,CC_measurement_wavelength,700.0,
 4220,CC_scattering_angle,124.0,
+4220,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04220__20201203.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04220__20201203.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4220,CC_depolarization_ratio,0.039,
 4220,CC_measurement_wavelength,700.0,
 4220,CC_scattering_angle,124.0,
+4220,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04220__20231130.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04220__20231130.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4220,CC_depolarization_ratio,0.039,
 4220,CC_measurement_wavelength,700.0,
 4220,CC_scattering_angle,124.0,
+4220,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTM/CGINS-FLORTM-04221__20160205.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04221__20160205.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4221,CC_depolarization_ratio,0.039,
 4221,CC_measurement_wavelength,700.0,
 4221,CC_scattering_angle,124.0,
+4221,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04221__20180210.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04221__20180210.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4221,CC_depolarization_ratio,0.039,
 4221,CC_measurement_wavelength,700.0,
 4221,CC_scattering_angle,124.0,
+4221,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04221__20201202.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04221__20201202.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4221,CC_depolarization_ratio,0.039,
 4221,CC_measurement_wavelength,700.0,
 4221,CC_scattering_angle,124.0,
+4221,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04221__20220804.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04221__20220804.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4221,CC_depolarization_ratio,0.039,
 4221,CC_measurement_wavelength,700.0,
 4221,CC_scattering_angle,124.0,
+4221,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04251__20160114.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04251__20160114.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4251,CC_depolarization_ratio,0.039,
 4251,CC_measurement_wavelength,700,
 4251,CC_scattering_angle,124,
+4251,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04251__20190724.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04251__20190724.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4251,CC_depolarization_ratio,0.039,
 4251,CC_measurement_wavelength,700,
 4251,CC_scattering_angle,124,
+4251,CC_cdom_correction_factor,2.505136,Sea-Bird provided CDOM correction factor: 2.505136 = 5.62 * 0.445754

--- a/calibration/FLORTM/CGINS-FLORTM-04251__20231201.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04251__20231201.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4251,CC_depolarization_ratio,0.039,
 4251,CC_measurement_wavelength,700,
 4251,CC_scattering_angle,124,
+4251,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTM/CGINS-FLORTM-04258__20160115.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04258__20160115.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4258,CC_depolarization_ratio,0.039,
 4258,CC_measurement_wavelength,700.0,
 4258,CC_scattering_angle,124.0,
+4258,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04258__20170925.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04258__20170925.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4258,CC_depolarization_ratio,0.039,
 4258,CC_measurement_wavelength,700.0,
 4258,CC_scattering_angle,124.0,
+4258,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04258__20191028.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04258__20191028.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4258,CC_depolarization_ratio,0.039,
 4258,CC_measurement_wavelength,700.0,
 4258,CC_scattering_angle,124.0,
+4258,CC_cdom_correction_factor,2.505136,Sea-Bird provided CDOM correction factor: 2.505136 = 5.62 * 0.445754

--- a/calibration/FLORTM/CGINS-FLORTM-04258__20220112.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04258__20220112.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4258,CC_depolarization_ratio,0.039,
 4258,CC_measurement_wavelength,700.0,
 4258,CC_scattering_angle,124.0,
+4258,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04267__20160114.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04267__20160114.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4267,CC_depolarization_ratio,0.039,
 4267,CC_measurement_wavelength,700.0,
 4267,CC_scattering_angle,124.0,
+4267,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04267__20180102.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04267__20180102.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4267,CC_depolarization_ratio,0.039,
 4267,CC_measurement_wavelength,700.0,
 4267,CC_scattering_angle,124.0,
+4267,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04267__20201202.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04267__20201202.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4267,CC_depolarization_ratio,0.039,
 4267,CC_measurement_wavelength,700.0,
 4267,CC_scattering_angle,124.0,
+4267,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04267__20230630.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04267__20230630.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4267,CC_depolarization_ratio,0.039,
 4267,CC_measurement_wavelength,700.0,
 4267,CC_scattering_angle,124.0,
+4267,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTM/CGINS-FLORTM-04332__20160418.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04332__20160418.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4332,CC_depolarization_ratio,0.039,
 4332,CC_measurement_wavelength,700.0,
 4332,CC_scattering_angle,124.0,
+4332,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04332__20190724.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04332__20190724.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4332,CC_depolarization_ratio,0.039,
 4332,CC_measurement_wavelength,700.0,
 4332,CC_scattering_angle,124.0,
+4332,CC_cdom_correction_factor,2.505136,Sea-Bird provided CDOM correction factor: 2.505136 = 5.62 * 0.445754

--- a/calibration/FLORTM/CGINS-FLORTM-04332__20220112.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04332__20220112.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4332,CC_depolarization_ratio,0.039,
 4332,CC_measurement_wavelength,700.0,
 4332,CC_scattering_angle,124.0,
+4332,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04332__20220913.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04332__20220913.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4332,CC_depolarization_ratio,0.039,
 4332,CC_measurement_wavelength,700.0,
 4332,CC_scattering_angle,124.0,
+4332,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04465__20160817.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04465__20160817.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4465,CC_depolarization_ratio,0.039,
 4465,CC_measurement_wavelength,700,
 4465,CC_scattering_angle,124,
+4465,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04465__20180103.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04465__20180103.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4465,CC_depolarization_ratio,0.039,
 4465,CC_measurement_wavelength,700,
 4465,CC_scattering_angle,124,
+4465,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04465__20200319.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04465__20200319.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4465,CC_depolarization_ratio,0.039,
 4465,CC_measurement_wavelength,700,
 4465,CC_scattering_angle,124,
+4465,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04466__20160817.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04466__20160817.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4466,CC_depolarization_ratio,0.039,
 4466,CC_measurement_wavelength,700,
 4466,CC_scattering_angle,124,
+4466,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04467__20160817.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04467__20160817.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4467,CC_depolarization_ratio,0.039,
 4467,CC_measurement_wavelength,700,
 4467,CC_scattering_angle,124,
+4467,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04467__20190911.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04467__20190911.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4467,CC_depolarization_ratio,0.039,
 4467,CC_measurement_wavelength,700,
 4467,CC_scattering_angle,124,
+4467,CC_cdom_correction_factor,2.505136,Sea-Bird provided CDOM correction factor: 2.505136 = 5.62 * 0.445754

--- a/calibration/FLORTM/CGINS-FLORTM-04467__20210728.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04467__20210728.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4467,CC_depolarization_ratio,0.039,
 4467,CC_measurement_wavelength,700,
 4467,CC_scattering_angle,124,
+4467,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04467__20220805.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04467__20220805.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4467,CC_depolarization_ratio,0.039,
 4467,CC_measurement_wavelength,700,
 4467,CC_scattering_angle,124,
+4467,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04468__20160817.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04468__20160817.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4468,CC_depolarization_ratio,0.039,
 4468,CC_measurement_wavelength,700,
 4468,CC_scattering_angle,124,
+4468,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04470__20160824.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04470__20160824.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4470,CC_depolarization_ratio,0.039,
 4470,CC_measurement_wavelength,700,
 4470,CC_scattering_angle,124,
+4470,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04470__20190724.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04470__20190724.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4470,CC_depolarization_ratio,0.039,
 4470,CC_measurement_wavelength,700,
 4470,CC_scattering_angle,124,
+4470,CC_cdom_correction_factor,2.505136,Sea-Bird provided CDOM correction factor: 2.505136 = 5.62 * 0.445754

--- a/calibration/FLORTM/CGINS-FLORTM-04470__20220805.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04470__20220805.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4470,CC_depolarization_ratio,0.039,
 4470,CC_measurement_wavelength,700.0,
 4470,CC_scattering_angle,124.0,
+4470,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04471__20160822.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04471__20160822.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4471,CC_depolarization_ratio,0.039,
 4471,CC_measurement_wavelength,700,
 4471,CC_scattering_angle,124,
+4471,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04471__20181101.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04471__20181101.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4471,CC_depolarization_ratio,0.039,
 4471,CC_measurement_wavelength,700,
 4471,CC_scattering_angle,124,
+4471,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04471__20201014.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04471__20201014.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4471,CC_depolarization_ratio,0.039,
 4471,CC_measurement_wavelength,700,
 4471,CC_scattering_angle,124,
+4471,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04471__20220808.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04471__20220808.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4471,CC_depolarization_ratio,0.039,
 4471,CC_measurement_wavelength,700,
 4471,CC_scattering_angle,124,
+4471,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04472__20160822.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04472__20160822.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4472,CC_depolarization_ratio,0.039,
 4472,CC_measurement_wavelength,700,
 4472,CC_scattering_angle,124,
+4472,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04472__20180103.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04472__20180103.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4472,CC_depolarization_ratio,0.039,
 4472,CC_measurement_wavelength,700,
 4472,CC_scattering_angle,124,
+4472,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04472__20201014.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04472__20201014.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4472,CC_depolarization_ratio,0.039,
 4472,CC_measurement_wavelength,700,
 4472,CC_scattering_angle,124,
+4472,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04472__20220805.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04472__20220805.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4472,CC_depolarization_ratio,0.039,
 4472,CC_measurement_wavelength,700,
 4472,CC_scattering_angle,124,
+4472,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04473__20160824.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04473__20160824.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4473,CC_depolarization_ratio,0.039,
 4473,CC_measurement_wavelength,700,
 4473,CC_scattering_angle,124,
+4473,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04473__20170925.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04473__20170925.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4473,CC_depolarization_ratio,0.039,
 4473,CC_measurement_wavelength,700,
 4473,CC_scattering_angle,124,
+4473,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-04473__20191028.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04473__20191028.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4473,CC_depolarization_ratio,0.039,
 4473,CC_measurement_wavelength,700,
 4473,CC_scattering_angle,124,
+4473,CC_cdom_correction_factor,2.505136,Sea-Bird provided CDOM correction factor: 2.505136 = 5.62 * 0.445754

--- a/calibration/FLORTM/CGINS-FLORTM-04473__20220119.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04473__20220119.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4473,CC_depolarization_ratio,0.039,
 4473,CC_measurement_wavelength,700,
 4473,CC_scattering_angle,124,
+4473,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-04473__20240318.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-04473__20240318.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 4473,CC_depolarization_ratio,0.039,
 4473,CC_measurement_wavelength,700.0,
 4473,CC_scattering_angle,124.0,
+4473,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTM/CGINS-FLORTM-05133__20180725.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-05133__20180725.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 5133,CC_depolarization_ratio,0.039,constant
 5133,CC_measurement_wavelength,700,constant
 5133,CC_scattering_angle,124,constant
+5133,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTM/CGINS-FLORTM-05133__20200210.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-05133__20200210.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 5133,CC_depolarization_ratio,0.039,constant
 5133,CC_measurement_wavelength,700,constant
 5133,CC_scattering_angle,124,constant
+5133,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-05133__20210728.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-05133__20210728.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 5133,CC_depolarization_ratio,0.039,constant
 5133,CC_measurement_wavelength,700,constant
 5133,CC_scattering_angle,124,constant
+5133,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-06168__20200225.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-06168__20200225.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 6168,CC_depolarization_ratio,0.039,constant
 6168,CC_measurement_wavelength,700,constant
 6168,CC_scattering_angle,124,constant
+6168,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-06642__20210112.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-06642__20210112.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 6642,CC_depolarization_ratio,0.039,
 6642,CC_measurement_wavelength,700,
 6642,CC_scattering_angle,124,
+6642,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-06744__20210318.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-06744__20210318.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 6744,CC_depolarization_ratio,0.039,
 6744,CC_measurement_wavelength,700,
 6744,CC_scattering_angle,124,
+6744,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-06744__20230915.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-06744__20230915.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 6744,CC_depolarization_ratio,0.039,
 6744,CC_measurement_wavelength,700.0,
 6744,CC_scattering_angle,124.0,
+6744,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTM/CGINS-FLORTM-07031__20210823.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-07031__20210823.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 7031,CC_depolarization_ratio,0.039,
 7031,CC_measurement_wavelength,700,
 7031,CC_scattering_angle,124,
+7031,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTM/CGINS-FLORTM-07031__20230628.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-07031__20230628.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 7031,CC_depolarization_ratio,0.039,
 7031,CC_measurement_wavelength,700.0,
 7031,CC_scattering_angle,124.0,
+7031,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTM/CGINS-FLORTM-08063__20230322.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-08063__20230322.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 8063,CC_depolarization_ratio,0.039,
 8063,CC_measurement_wavelength,700,
 8063,CC_scattering_angle,124,
+8063,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTM/CGINS-FLORTM-08412__20230802.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-08412__20230802.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 8412,CC_depolarization_ratio,0.039,
 8412,CC_measurement_wavelength,700.0,
 8412,CC_scattering_angle,124.0,
+8412,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTM/CGINS-FLORTM-08440__20230815.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-08440__20230815.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 8440,CC_depolarization_ratio,0.039,
 8440,CC_measurement_wavelength,700.0,
 8440,CC_scattering_angle,124.0,
+8440,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTM/CGINS-FLORTM-08603__20231116.csv
+++ b/calibration/FLORTM/CGINS-FLORTM-08603__20231116.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 8603,CC_depolarization_ratio,0.039,
 8603,CC_measurement_wavelength,700,
 8603,CC_scattering_angle,124,
+8603,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTN/CGINS-FLORTN-01108__20130926.csv
+++ b/calibration/FLORTN/CGINS-FLORTN-01108__20130926.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1108,CC_depolarization_ratio,0.039,
 1108,CC_measurement_wavelength,700,
 1108,CC_scattering_angle,124,
+1108,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTN/CGINS-FLORTN-01108__20180221.csv
+++ b/calibration/FLORTN/CGINS-FLORTN-01108__20180221.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1108,CC_depolarization_ratio,0.039,
 1108,CC_measurement_wavelength,700,
 1108,CC_scattering_angle,124,
+1108,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTN/CGINS-FLORTN-01109__20130926.csv
+++ b/calibration/FLORTN/CGINS-FLORTN-01109__20130926.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1109,CC_depolarization_ratio,0.039,
 1109,CC_measurement_wavelength,700,
 1109,CC_scattering_angle,124,
+1109,CC_cdom_correction_factor,1.669857,Sea-Bird provided CDOM correction factor: 1.669857 = 5.62 * 0.297127

--- a/calibration/FLORTN/CGINS-FLORTN-01109__20180619.csv
+++ b/calibration/FLORTN/CGINS-FLORTN-01109__20180619.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1109,CC_depolarization_ratio,0.039,
 1109,CC_measurement_wavelength,700,
 1109,CC_scattering_angle,124,
+1109,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTN/CGINS-FLORTN-01645__20171120.csv
+++ b/calibration/FLORTN/CGINS-FLORTN-01645__20171120.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1645,CC_depolarization_ratio,0.039,
 1645,CC_measurement_wavelength,700,
 1645,CC_scattering_angle,124,
+1645,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTN/CGINS-FLORTN-01646__20180110.csv
+++ b/calibration/FLORTN/CGINS-FLORTN-01646__20180110.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1646,CC_depolarization_ratio,0.039,
 1646,CC_measurement_wavelength,700,
 1646,CC_scattering_angle,124,
+1646,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTN/CGINS-FLORTN-08364__20230703.csv
+++ b/calibration/FLORTN/CGINS-FLORTN-08364__20230703.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 8364,CC_depolarization_ratio,0.039,
 8364,CC_measurement_wavelength,700,
 8364,CC_scattering_angle,124,
+8364,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTN/CGINS-FLORTN-08365__20230703.csv
+++ b/calibration/FLORTN/CGINS-FLORTN-08365__20230703.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 8365,CC_depolarization_ratio,0.039,
 8365,CC_measurement_wavelength,700,
 8365,CC_scattering_angle,124,
+8365,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTO/CGINS-FLORTO-01239__20140731.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01239__20140731.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1239,CC_depolarization_ratio,0.039,
 1239,CC_measurement_wavelength,700.0,
 1239,CC_scattering_angle,124.0,
+1239,CC_cdom_correction_factor,1.245926,Sea-Bird provided CDOM correction factor: 1.245926 = 5.62 * 0.221695

--- a/calibration/FLORTO/CGINS-FLORTO-01239__20170706.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01239__20170706.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1239,CC_depolarization_ratio,0.039,
 1239,CC_measurement_wavelength,700.0,
 1239,CC_scattering_angle,124.0,
+1239,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01239__20200310.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01239__20200310.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1239,CC_depolarization_ratio,0.039,
 1239,CC_measurement_wavelength,700.0,
 1239,CC_scattering_angle,124.0,
+1239,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTO/CGINS-FLORTO-01239__20220126.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01239__20220126.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1239,CC_depolarization_ratio,0.039,
 1239,CC_measurement_wavelength,700.0,
 1239,CC_scattering_angle,124.0,
+1239,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTO/CGINS-FLORTO-01240__20140731.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01240__20140731.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1240,CC_depolarization_ratio,0.039,
 1240,CC_measurement_wavelength,700,
 1240,CC_scattering_angle,124,
+1240,CC_cdom_correction_factor,1.245926,Sea-Bird provided CDOM correction factor: 1.245926 = 5.62 * 0.221695

--- a/calibration/FLORTO/CGINS-FLORTO-01329__20150624.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01329__20150624.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1329,CC_depolarization_ratio,0.039,
 1329,CC_measurement_wavelength,700,
 1329,CC_scattering_angle,124,
+1329,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01330__20151124.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01330__20151124.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1330,CC_depolarization_ratio,0.039,
 1330,CC_measurement_wavelength,700,
 1330,CC_scattering_angle,124,
+1330,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01330__20190913.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01330__20190913.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1330,CC_depolarization_ratio,0.039,
 1330,CC_measurement_wavelength,700,
 1330,CC_scattering_angle,124,
+1330,CC_cdom_correction_factor,2.505136,Sea-Bird provided CDOM correction factor: 2.505136 = 5.62 * 0.445754

--- a/calibration/FLORTO/CGINS-FLORTO-01331__20150624.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01331__20150624.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1331,CC_depolarization_ratio,0.039,
 1331,CC_measurement_wavelength,700,
 1331,CC_scattering_angle,124,
+1331,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01331__20210729.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01331__20210729.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1331,CC_depolarization_ratio,0.039,
 1331,CC_measurement_wavelength,700,
 1331,CC_scattering_angle,124,
+1331,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTO/CGINS-FLORTO-01332__20151220.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01332__20151220.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1332,CC_depolarization_ratio,0.039,
 1332,CC_measurement_wavelength,700,
 1332,CC_scattering_angle,124,
+1332,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01332__20190327.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01332__20190327.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1332,CC_depolarization_ratio,0.039,
 1332,CC_measurement_wavelength,700,
 1332,CC_scattering_angle,124,
+1332,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01332__20220329.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01332__20220329.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1332,CC_depolarization_ratio,0.039,
 1332,CC_measurement_wavelength,700,
 1332,CC_scattering_angle,124,
+1332,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTO/CGINS-FLORTO-01333__20151220.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01333__20151220.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1333,CC_depolarization_ratio,0.039,
 1333,CC_measurement_wavelength,700,
 1333,CC_scattering_angle,124,
+1333,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01333__20190327.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01333__20190327.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1333,CC_depolarization_ratio,0.039,
 1333,CC_measurement_wavelength,700,
 1333,CC_scattering_angle,124,
+1333,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01333__20250103.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01333__20250103.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1333,CC_depolarization_ratio,0.039,
 1333,CC_measurement_wavelength,700,
 1333,CC_scattering_angle,124,
+1333,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTO/CGINS-FLORTO-01342__20150924.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01342__20150924.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1342,CC_depolarization_ratio,0.039,
 1342,CC_measurement_wavelength,700,
 1342,CC_scattering_angle,124,
+1342,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01342__20201015.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01342__20201015.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1342,CC_depolarization_ratio,0.039,
 1342,CC_measurement_wavelength,700,
 1342,CC_scattering_angle,124,
+1342,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTO/CGINS-FLORTO-01342__20220307.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01342__20220307.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1342,CC_depolarization_ratio,0.039,
 1342,CC_measurement_wavelength,700,
 1342,CC_scattering_angle,124,
+1342,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTO/CGINS-FLORTO-01343__20150923.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01343__20150923.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1343,CC_depolarization_ratio,0.039,
 1343,CC_measurement_wavelength,700,
 1343,CC_scattering_angle,124,
+1343,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01344__20150914.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01344__20150914.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1344,CC_depolarization_ratio,0.039,
 1344,CC_measurement_wavelength,700,
 1344,CC_scattering_angle,124,
+1344,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01345__20150914.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01345__20150914.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1345,CC_depolarization_ratio,0.039,
 1345,CC_measurement_wavelength,700,
 1345,CC_scattering_angle,124,
+1345,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01346__20150914.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01346__20150914.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1346,CC_depolarization_ratio,0.039,
 1346,CC_measurement_wavelength,700,
 1346,CC_scattering_angle,124,
+1346,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01347__20140916.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01347__20140916.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1347,CC_depolarization_ratio,0.039,
 1347,CC_measurement_wavelength,700,
 1347,CC_scattering_angle,124,
+1347,CC_cdom_correction_factor,1.245926,Sea-Bird provided CDOM correction factor: 1.245926 = 5.62 * 0.221695

--- a/calibration/FLORTO/CGINS-FLORTO-01347__20200306.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01347__20200306.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1347,CC_depolarization_ratio,0.039,
 1347,CC_measurement_wavelength,700,
 1347,CC_scattering_angle,124,
+1347,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTO/CGINS-FLORTO-01347__20220802.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01347__20220802.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1347,CC_depolarization_ratio,0.039,
 1347,CC_measurement_wavelength,700,
 1347,CC_scattering_angle,124,
+1347,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTO/CGINS-FLORTO-01348__20150923.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01348__20150923.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1348,CC_depolarization_ratio,0.039,
 1348,CC_measurement_wavelength,700,
 1348,CC_scattering_angle,124,
+1348,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01348__20190708.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01348__20190708.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1348,CC_depolarization_ratio,0.039,
 1348,CC_measurement_wavelength,700,
 1348,CC_scattering_angle,124,
+1348,CC_cdom_correction_factor,2.505136,Sea-Bird provided CDOM correction factor: 2.505136 = 5.62 * 0.445754

--- a/calibration/FLORTO/CGINS-FLORTO-01348__20210715.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01348__20210715.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1348,CC_depolarization_ratio,0.039,
 1348,CC_measurement_wavelength,700,
 1348,CC_scattering_angle,124,
+1348,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTO/CGINS-FLORTO-01348__20231227.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01348__20231227.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1348,CC_depolarization_ratio,0.039,
 1348,CC_measurement_wavelength,700,
 1348,CC_scattering_angle,124,
+1348,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTO/CGINS-FLORTO-01349__20150925.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01349__20150925.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 1349,CC_depolarization_ratio,0.039,
 1349,CC_measurement_wavelength,700,
 1349,CC_scattering_angle,124,
+1349,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-07929__20221128.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-07929__20221128.csv
@@ -3,3 +3,4 @@ serial,name,value,notes
 7929,CC_depolarization_ratio,0.039,
 7929,CC_measurement_wavelength,700.0,
 7929,CC_scattering_angle,124.0,
+7929,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213


### PR DESCRIPTION
This is the pull request that adds the Sea-Bird provided CDOM correction factors to all (EA and CGSN) gliders and AUVs to a parameter in the FLORT calibration csv files.  I rounded the correction values to 6 decimal places (as little as 2 decimal places were needed).

I highly suggest instead of reviewing ALL 234 file additions by human eye, that you create a local branch from the pull request using:
`git fetch git@github.com:oceanobservatories/asset-management.git pull/1259/head:<local branch name>`
renaming `<local branch name>` to whatever you want (e.g. glider_cdom).
and then use the spreadsheet given to us by Matt Palanza and use a script to check the values entered.
I can help with this if you want a script and more detailed instructions.

Alternatively, I used a python script from the CSV file Matt gave us to add the values.  So, I would consider it good enough to review that a handful of randomly chosen files (e.g. 10 files and ensuring a few from each instrument class) have the correct correction values added from the spreadsheet.  If a handful of random file checks are all correct, then it means my script worked and it is extremely likely that all files were updated correctly.  Also be sure to check a few where the correction factor is 1.00.